### PR TITLE
add name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "dspam"
 maintainer       "computerlyrik"
 maintainer_email "chef-cookbooks@computerlyrik.de"
 license          "Apache 2.0"


### PR DESCRIPTION
```
Ridley::Errors::MissingNameAttribute: The metadata does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```