### PR TITLE
remove duplicate definition

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,6 @@ default[:dspam][:spamAction]="deliver"
 default[:dspam][:spamSubject]="[SPAM]"
 default[:dspam][:enableBNR]="on"
 default[:dspam][:enableWhitelist]="on"
-default[:dspam][:enableBNR]="on"
 default[:dspam][:statisticalSedation]=5
 default[:dspam][:signatureLocation]="message"
 default[:dspam][:whitelistThreshold]=10


### PR DESCRIPTION
This attribute is already defined on [line 9](#diff-25e5d4a4446ae12a0d6f1162b6160375R9)